### PR TITLE
The config load should be relative to the script that is running and …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,10 @@
   load_config = function(opts) {
     var configs, dir;
     configs = {};
-    dir = path.resolve(process.cwd(), opts.path);
+
+    // The config load should be relative to the script that is running and not
+    // to the directory where you are running the script.
+    dir = path.resolve(__dirname, '../../..', opts.path);
     load_files(dir).forEach(function(file) {
       var config;
       config = extensions[file.extension].parse(file.content);


### PR DESCRIPTION
…not the directory where you are running the script.

I am running node like this: /local/bin/node PATH/TO/MY/SCRIPT

Using process.cwd() is okay when you run the code from the root app. My change is making it relative where your lib is. Maybe it is not elegant but it does the job. Are you okay merging it? Or do you suggest a better way to do it?