### PR TITLE
Fixing the vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "cson": "~2.0.0",
-    "js-yaml": "~3.2.7",
+    "js-yaml": "^3.13.1",
     "lazy.js": "~0.4.0"
   },
   "license": "LGPL-3.0"


### PR DESCRIPTION
Js-yaml prior to 3.13.1 are vulnerable to Code Injection. The load() function may execute arbitrary code injected through a malicious YAML file.

Reference URL: https://github.com/nodeca/js-yaml/pull/480

Test Passed after upgrading the js-yaml dependency:

![image](https://user-images.githubusercontent.com/14198567/60511940-d5872a00-9cf0-11e9-9561-76ba376a7488.png)
